### PR TITLE
Much further Homebridge 2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function PeopleAccessory(log, config, platform) {
         format: HomebridgeAPI.hap.Formats.UINT32,
         unit: HomebridgeAPI.hap.Units.SECONDS,
         perms: [
-          HomebridgeAPI.hap.Perms.READ,
+          HomebridgeAPI.hap.Perms.PAIRED_READ,
           HomebridgeAPI.hap.Perms.NOTIFY,
         ],
       });
@@ -197,9 +197,9 @@ function PeopleAccessory(log, config, platform) {
         maxValue: 7,
         validValues: [0, 4, 7],
         perms: [
-          Characteristic.Perms.READ,
-          Characteristic.Perms.NOTIFY,
-          Characteristic.Perms.WRITE,
+          HomebridgeAPI.hap.Perms.PAIRED_READ,
+          HomebridgeAPI.hap.Perms.NOTIFY,
+          HomebridgeAPI.hap.Perms.PAIRED_WRITE,
         ],
       });
     }
@@ -219,9 +219,9 @@ function PeopleAccessory(log, config, platform) {
           1 * 3600, 2 * 3600, 3 * 3600, 5 * 3600, 10 * 3600, 12 * 3600, 15 * 3600,
         ],
         perms: [
-          HomebridgeAPI.hap.Perms.READ,
+          HomebridgeAPI.hap.Perms.PAIRED_READ,
           HomebridgeAPI.hap.Perms.NOTIFY,
-          HomebridgeAPI.hap.Perms.WRITE,
+          HomebridgeAPI.hap.Perms.PAIRED_WRITE,
         ],
       });
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   ],
   "dependencies": {
-    "fakegato-history": "^0.5.0",
+    "fakegato-history": "^0.6.7",
     "moment": "^2.11.2",
     "node-persist": "0.0.8",
     "ping": "^0.1.10",


### PR DESCRIPTION
Sorry that last PR missed one revision. Also needed syncing up with latest [fakegato-history](https://github.com/simont77/fakegato-history) to work on Homebridge v2 and EVE. See https://github.com/simont77/fakegato-history/issues/132.